### PR TITLE
fix: update answer for Q 120

### DIFF
--- a/AWS SAA-03 Solution.txt
+++ b/AWS SAA-03 Solution.txt
@@ -775,7 +775,8 @@ A. Set up AWS WAF in both Regions. Associate Regional web ACLs with an API stage
 
 120.A company has implemented a self-managed DNS solution on three Amazon EC2 instances behind a Network Load Balancer (NLB) in the us-west-2 Region. Most of the company's users are located in the United States and Europe. The company wants to improve the performance and availability of the solution. The company launches and configures three EC2 instances in the eu-west-1 Region and adds the EC2 instances as targets for a new NLB.
 Which solution can the company use to route traffic to all the EC2 instances? 
-A. Create an Amazon Route 53 geolocation routing policy to route requests to one of the two NLBs. Create an Amazon CloudFront distribution. Use the Route 53 record as the distribution’s origin. 
+B. Create a standard accelerator in AWS Global Accelerator. Create endpoint groups in us-west-2 and eu-west-1. Add the two NLBs as
+endpoints for the endpoint groups.
 
 121.A company is running an online transaction processing (OLTP) workload on AWS. This workload uses an unencrypted Amazon RDS DB instance in a Multi-AZ deployment. Daily database snapshots are taken from this instance.
 What should a solutions architect do to ensure the database and snapshots are always encrypted moving forward? 


### PR DESCRIPTION
Global Accelerator gives anycast static IPs, routes users to the nearest healthy Region over the AWS global network, improves latency and availability, and natively supports NLB endpoints across Regions. Exactly fits “improve performance and availability” and “route traffic to all EC2 instances.”

A (Route 53 geolocation + CloudFront): Geolocation is coarse and not health/latency adaptive; CloudFront is a CDN for HTTP(S)/content, not ideal for DNS-over-UDP/TCP or arbitrary ports behind NLB.