### PR TITLE
fix: update answer for Q 139

### DIFF
--- a/AWS SAA-03 Solution.txt
+++ b/AWS SAA-03 Solution.txt
@@ -859,7 +859,8 @@ B. Migrate the queue to a redundant pair (active/standby) of RabbitMQ instances 
 139.A reporting team receives files each day in an Amazon S3 bucket. The reporting team manually reviews and copies the files from this initial S3 bucket to an analysis S3 bucket each day at the same time to use with Amazon QuickSight. Additional teams are starting to send more files in larger sizes to the initial S3 bucket.
 The reporting team wants to move the files automatically analysis S3 bucket as the files enter the initial S3 bucket. The reporting team also wants to use AWS Lambda functions to run pattern-matching code on the copied data. In addition, the reporting team wants to send the data files to a pipeline in Amazon SageMaker Pipelines.
 What should a solutions architect do to meet these requirements with the LEAST operational overhead?
-A. Create a Lambda function to copy the files to the analysis S3 bucket. Create an S3 event notification for the analysis S3 bucket. Configure Lambda and SageMaker Pipelines as destinations of the event notification. Configure s3:ObjectCreated:Put as the event type. 
+C. Configure S3 replication between the S3 buckets. Create an S3 event notification for the analysis S3 bucket. Configure Lambda and
+SageMaker Pipelines as destinations of the event notification. Configure s3:ObjectCreated:Put as the event type.
 
 IMP>>>>>>>>>140.A solutions architect needs to help a company optimize the cost of running an application on AWS. The application will use Amazon EC2 instances, AWS Fargate, and AWS Lambda for compute within the architecture.
 The EC2 instances will run the data ingestion layer of the application. EC2 usage will be sporadic and unpredictable. Workloads that run on EC2 instances can be interrupted at any time. The application front end will run on Fargate, and Lambda will serve the API layer. The front-end utilization and API layer utilization will be predictable over the course of the next year.


### PR DESCRIPTION
Why this is best (least ops):
- Automatic copy: S3 replication moves new objects from the intake bucket to the analysis bucket without custom code or scheduling.
- Event-driven processing on the copy: An event notification on the destination (analysis) bucket guarantees Lambda and SageMaker Pipelines trigger only after the object is present where QuickSight reads it.
- Minimal moving parts: No custom Lambda just to copy, no EventBridge rules needed.

Why not the others:
- A / B: You’re writing a Lambda copier, which adds code, retries, error handling, and scaling concerns—more operational overhead than built-in replication.
- D: Adds EventBridge unnecessarily; S3 native event notifications on the analysis bucket are simpler and sufficient.