### PR TITLE
fix: update Q137 answer

### DIFF
--- a/AWS SAA-03 Solution.txt
+++ b/AWS SAA-03 Solution.txt
@@ -849,7 +849,8 @@ D. Convert the database schema by using the AWS Schema Conversion Tool (AWS SCT)
 
 137.A company uses AWS Organizations to create dedicated AWS accounts for each business unit to manage each business unit's account independently upon request. The root email recipient missed a notification that was sent to the root user email address of one account. The company wants to ensure that all future notifications are not missed. Future notifications must be limited to account administrators.
 Which solution will meet these requirements? 
-D. Configure all existing AWS accounts and all newly created accounts to use the same root user email address. Configure AWS account alternate contacts in the AWS Organizations console or programmatically. 
+B. Configure all AWS account root user email addresses as distribution lists that go to a few administrators who can respond to alerts.
+Configure AWS account alternate contacts in the AWS Organizations console or programmatically.
 
 138.A company runs its ecommerce application on AWS. Every new order is published as a massage in a RabbitMQ queue that runs on an Amazon EC2 instance in a single Availability Zone. These messages are processed by a different application that runs on a separate EC2 instance. This application stores the details in a PostgreSQL database on another EC2 instance. All the EC2 instances are in the same Availability Zone.
 The company needs to redesign its architecture to provide the highest availability with the least operational overhead.


### PR DESCRIPTION
> The root email recipient missed a notification that was sent to the root user email address of one account. The
company wants to ensure that all future notifications are not missed. Future notifications must be limited to account administrators.

To prevent missed notification emails, sending the emails to a distribution list instead of a single person is probably the best option.

https://docs.aws.amazon.com/prescriptive-guidance/latest/aws-startup-security-baseline/acct-01.html